### PR TITLE
Fix broken cld2 dependency, changing to pycld2

### DIFF
--- a/multi_rake/utils.py
+++ b/multi_rake/utils.py
@@ -1,4 +1,4 @@
-import cld2
+import pycld2
 import regex
 
 LETTERS_RE = regex.compile(r'\p{L}+')
@@ -11,7 +11,7 @@ SENTENCE_DELIMITERS_RE = regex.compile(
 
 
 def detect_language(text, proba_threshold):
-    _, _, details = cld2.detect(text)
+    _, _, details = pycld2.detect(text)
 
     language_code = details[0].language_code
     probability = details[0].percent

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -1,4 +1,4 @@
-cld2-cffi>=0.1.4
 numpy>=1.14.4
+pycld2>=0.41
 pyrsistent>=0.14.2
 regex>=2018.6.6


### PR DESCRIPTION
In response to issues #37 and #36 I changed the trouble-making dependency cld2-cffi to pycld2.